### PR TITLE
fix: handle EPIPE crash and align review output with Codex format

### DIFF
--- a/plugins/gemini/scripts/gemini-companion.mjs
+++ b/plugins/gemini/scripts/gemini-companion.mjs
@@ -33,6 +33,7 @@ import { interpolateTemplate, loadPromptTemplate } from "./lib/prompts.mjs";
 import {
   renderCancelReport,
   renderJobStatusReport,
+  renderReviewResult,
   renderSetupReport,
   renderStatusReport,
   renderStoredJobResult,
@@ -518,28 +519,13 @@ async function executeReviewRun(request) {
     stopReason,
   };
 
-  const lines = [
-    `Verdict: ${reviewResult.verdict}`,
-    `Summary: ${reviewResult.summary}`,
-  ];
-  if (reviewResult.findings?.length > 0) {
-    lines.push(`Findings: ${reviewResult.findings.length}`);
-    for (const finding of reviewResult.findings) {
-      lines.push(`  [${finding.severity}] ${finding.title}`);
-    }
-  }
-  if (reviewResult.next_steps?.length > 0) {
-    lines.push("Next steps:");
-    for (const step of reviewResult.next_steps) {
-      lines.push(`  - ${step}`);
-    }
-  }
-  const rendered = `${lines.join("\n")}\n`;
-
   return {
     exitStatus: 0,
     payload,
-    rendered,
+    rendered: renderReviewResult(
+      { parsed: reviewResult },
+      { reviewLabel: reviewName, targetLabel: target.label },
+    ),
     summary: reviewResult.summary ?? `${reviewName} finished.`,
     jobTitle: `Gemini ${reviewName}`,
     jobClass: "review",
@@ -799,6 +785,19 @@ main().then(
           lines.push(`- --model ${s}`);
         }
       }
+      process.stderr.write(`${lines.join("\n")}\n`);
+    } else if (error?.code === "ACP_PROCESS_EXIT") {
+      const lines = [
+        `# Gemini Error`,
+        ``,
+        `The Gemini ACP process exited unexpectedly (code ${error.exitCode ?? "unknown"}).`,
+        ``,
+        `This can happen when multiple Gemini sessions are already running and the`,
+        `CLI cannot initialize a new one. Cancel active jobs or wait for them to finish:`,
+        ``,
+        `  /gemini:status   — see what is running`,
+        `  /gemini:cancel   — cancel a specific job`,
+      ];
       process.stderr.write(`${lines.join("\n")}\n`);
     } else {
       const message = error instanceof Error ? error.message : String(error);

--- a/plugins/gemini/scripts/lib/acp-client.mjs
+++ b/plugins/gemini/scripts/lib/acp-client.mjs
@@ -13,11 +13,11 @@ export class AcpClient {
 
   constructor(proc) {
     this.#proc = proc;
-    // Suppress EPIPE and other stdin write errors. In Node.js, stream errors
-    // are emitted as events, not thrown synchronously — without this handler
-    // they become uncaught exceptions and crash the process. Pending promise
-    // rejection when the process dies is handled by #onExit.
-    proc.stdin.on("error", () => {});
+    // Handle EPIPE and other stdin write errors. In Node.js, stream errors are
+    // emitted as events, not thrown synchronously — without this handler they
+    // become uncaught exceptions and crash the process. Calling #onExit drains
+    // any pending promises; it's idempotent via the #closed guard.
+    proc.stdin.on("error", () => this.#onExit(1));
     this.#rl = readline.createInterface({
       input: proc.stdout,
       crlfDelay: Infinity,

--- a/plugins/gemini/scripts/lib/acp-client.mjs
+++ b/plugins/gemini/scripts/lib/acp-client.mjs
@@ -13,6 +13,11 @@ export class AcpClient {
 
   constructor(proc) {
     this.#proc = proc;
+    // Suppress EPIPE and other stdin write errors. In Node.js, stream errors
+    // are emitted as events, not thrown synchronously — without this handler
+    // they become uncaught exceptions and crash the process. Pending promise
+    // rejection when the process dies is handled by #onExit.
+    proc.stdin.on("error", () => {});
     this.#rl = readline.createInterface({
       input: proc.stdout,
       crlfDelay: Infinity,


### PR DESCRIPTION
## Summary

Two bugs fixed in a single PR — both were discovered while running concurrent Gemini sessions and examining why `/gemini:rescue` had less context than `/codex:rescue`.

- **EPIPE crash**: When multiple Gemini sessions are already running and the `gemini --acp` process fails to initialize, the node process now exits cleanly with a clear error message instead of crashing with an uncaught EPIPE exception
- **Review output format**: `/gemini:review` and `/gemini:adversarial-review` now use `renderReviewResult` from `render.mjs`, matching the Codex output format — full findings with file, line range, body, and recommendations instead of a terse summary-only list

## Details

### EPIPE crash (`acp-client.mjs`)

`AcpClient` had no `error` handler on `proc.stdin`. In Node.js, write errors on a stream are emitted as events, not thrown synchronously — so the `try/catch` in `#send` does not catch them. When `gemini --acp` exits unexpectedly (e.g., resource exhaustion from 3+ concurrent sessions), the next `stdin.write` emits `EPIPE` on the stream, which without a handler becomes an uncaught exception that crashes the entire node process.

Fix: `proc.stdin.on("error", () => {})` in the constructor. The existing `#onExit` handler already rejects pending promises correctly when the process dies — so the error still surfaces, just as `ACP_PROCESS_EXIT` instead of a crash.

Additionally added `ACP_PROCESS_EXIT` handling in the `gemini-companion.mjs` main error handler so the user sees:
```
# Gemini Error

The Gemini ACP process exited unexpectedly (code 1).

This can happen when multiple Gemini sessions are already running and the
CLI cannot initialize a new one. Cancel active jobs or wait for them to finish:

  /gemini:status   — see what is running
  /gemini:cancel   — cancel a specific job
```

### Review output format (`gemini-companion.mjs`)

`executeReviewRun` was building its own terse inline output (verdict + finding titles only), ignoring the full `renderReviewResult` function already present in `render.mjs`. The saved `~/.gemini-plugin/last-review-<hash>.md` was therefore missing file paths, line numbers, finding bodies, and recommendations — all the context that `/gemini:rescue` needs to fix issues.

Fix: import `renderReviewResult` and call it instead of the inline builder. The normalized result from `parseReviewOutput` is already the right shape; `normalizeReviewResultData` inside `renderReviewResult` is idempotent, so double-normalization is safe.

Output before:
```
Verdict: needs-attention
Summary: Found 2 issues
Findings: 2
  [high] Missing error handling
  [medium] Unused variable
```

Output after (matching Codex format):
```
# Gemini Review

Target: working tree
Verdict: needs-attention

Found 2 issues

Findings:
- [high] Missing error handling (src/handler.ts:42)
  The function does not handle the rejection case from the async call.
  Recommendation: Wrap in try/catch or add .catch()
- [medium] Unused variable (src/utils.ts:15)
  Variable `temp` is declared but never read.
  Recommendation: Remove the declaration

Next steps:
- Add error boundary around the async handler
```

## Test plan

- [ ] Run `/gemini:review` with 3+ concurrent background Gemini jobs — should fail with a clean error message instead of crashing
- [ ] Run `/gemini:review` normally — verify output includes file, line, body, and recommendations for each finding
- [ ] Run `/gemini:adversarial-review` — same format verification
- [ ] Verify `~/.gemini-plugin/last-review-<hash>.md` contains the full formatted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)