### PR TITLE
fix: align adversarial-review prompt verdicts and inline schema with JSON schema

### DIFF
--- a/plugins/gemini/prompts/adversarial-review.md
+++ b/plugins/gemini/prompts/adversarial-review.md
@@ -47,12 +47,12 @@ A finding should answer:
 <structured_output_contract>
 Return only valid JSON matching the provided schema.
 Keep the output compact and specific.
-Use `needs-attention` if there is any material risk worth blocking on.
-Use `approve` only if you cannot support any substantive adversarial finding from the provided context.
+Use `no-ship` if the change has critical issues that must be fixed before merging.
+Use `needs-attention` if there is any material risk worth addressing.
+Use `no-issues` only if you cannot support any substantive adversarial finding from the provided context.
 Every finding must include:
 - the affected file
 - `line_start` and `line_end`
-- a confidence score from 0 to 1
 - a concrete recommendation
 Write the summary like a terse ship/no-ship assessment, not a neutral recap.
 </structured_output_contract>

--- a/plugins/gemini/prompts/adversarial-review.md
+++ b/plugins/gemini/prompts/adversarial-review.md
@@ -61,7 +61,7 @@ Write the summary like a terse ship/no-ship assessment, not a neutral recap.
 Be aggressive, but stay grounded.
 Every finding must be defensible from the provided repository context or tool outputs.
 Do not invent files, lines, code paths, incidents, attack chains, or runtime behavior you cannot support.
-If a conclusion depends on an inference, state that explicitly in the finding body and keep the confidence honest.
+If a conclusion depends on an inference, state that explicitly in the finding body.
 </grounding_rules>
 
 <calibration_rules>

--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -208,7 +208,7 @@ function buildReviewPrompt(reviewTarget, systemPrompt, focusText) {
     parts.push(`\n\nAdditional focus: ${focusText}`);
   }
   parts.push(
-    `\n\nRespond with ONLY valid JSON matching this schema — no prose, no markdown fences:\n{"verdict":"no-issues"|"needs-attention"|"no-ship","summary":"...","findings":[{"severity":"critical|high|medium|low","title":"...","body":"...","file":"...","line_start":N,"recommendation":"..."}],"next_steps":["..."]}`,
+    `\n\nRespond with ONLY valid JSON matching this schema — no prose, no markdown fences:\n{"verdict":"no-issues"|"needs-attention"|"no-ship","summary":"...","findings":[{"severity":"critical|high|medium|low","title":"...","body":"...","file":"...","line_start":N,"line_end":N,"recommendation":"..."}],"next_steps":["..."]}`,
   );
   return parts.join("");
 }


### PR DESCRIPTION
## Summary

The adversarial-review prompt told the LLM to use `approve` as a verdict, but the Gemini schema only allows `no-issues`, `needs-attention`, and `no-ship`. Whenever the LLM followed the prompt and returned `approve`, `parseReviewOutput` threw `REVIEW_VALIDATION_ERROR` and the entire review failed silently.

## Changes

**`prompts/adversarial-review.md`**
- `approve` → `no-issues` — matches the actual schema enum
- Added `no-ship` guidance — it was a valid verdict in the schema but never mentioned in the prompt, so the LLM never used it (adversarial review is exactly the context where `no-ship` belongs)
- Removed the `confidence score from 0 to 1` requirement — confidence is not in the inline JSON schema, not in the response normalization, and not rendered in output; asking for it created noise that made LLM responses inconsistent

**`scripts/lib/gemini.mjs`**
- Added `line_end` to the inline JSON schema instruction. The prompt required both `line_start` and `line_end`, but the inline schema only showed `line_start`. The LLM inconsistently omitted `line_end` because the final schema instruction didn't include it.

## Before / After

Before: LLM sees "use `approve`" in system prompt and `no-issues|needs-attention|no-ship` in inline schema — contradiction leads to either a validation crash or ignored guidance.

After: every layer agrees:
- System prompt: `no-issues` / `needs-attention` / `no-ship` with clear usage guidance
- Inline JSON schema: `no-issues|needs-attention|no-ship` with `line_start` and `line_end`
- JSON schema file: `no-issues`, `needs-attention`, `no-ship`

## Test plan

- [ ] Run `/gemini:adversarial-review` — verify it completes without `REVIEW_VALIDATION_ERROR`
- [ ] Confirm output uses `no-issues`, `needs-attention`, or `no-ship` — never `approve`
- [ ] Confirm findings include both `line_start` and `line_end` when the LLM provides them