### PR TITLE
Fix ACP init timeout and clean up on timeout (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ After install, you should see:
 - the slash commands listed below
 - the `gemini:gemini-rescue` subagent in `/agents`
 
+## Configuration
+
+| Variable | Purpose |
+|---|---|
+| `GOOGLE_API_KEY` | API key from AI Studio. Alternative to `gcloud auth application-default login`. |
+| `GEMINI_ACP_INIT_TIMEOUT_MS` | Override the 30s ACP initialize timeout. Bump it if Gemini CLI cold-start is slow on your machine (e.g. Homebrew installs that fall back to a file-based keychain). |
+
 ## Commands
 
 | Command | Description |

--- a/plugins/gemini/commands/setup.md
+++ b/plugins/gemini/commands/setup.md
@@ -18,5 +18,8 @@ If Gemini is installed but not authenticated:
 - Tell the user to set the `GOOGLE_API_KEY` environment variable or configure Application Default Credentials.
 - Preserve any guidance in the setup output.
 
+If setup passes but `/gemini:review`, `/gemini:rescue`, or `/gemini:task` fail with "ACP initialize timed out":
+- Tell the user to set `GEMINI_ACP_INIT_TIMEOUT_MS` to a higher value (e.g. `60000`). Common on Homebrew installs where keytar falls back to a file-based keychain.
+
 Output rules:
 - Present the final setup output to the user.

--- a/plugins/gemini/scripts/lib/acp-client.mjs
+++ b/plugins/gemini/scripts/lib/acp-client.mjs
@@ -170,6 +170,35 @@ export class AcpClient {
     return this.#request("session/list", { cwd });
   }
 
+  /**
+   * SIGKILL the child and reject pending requests. For cleanup after a failed init.
+   * @param {Error|string} [reason]
+   */
+  killImmediately(reason) {
+    if (this.#closed) return;
+    this.#closed = true;
+    const err =
+      reason instanceof Error
+        ? reason
+        : new Error(reason ?? "ACP client killed");
+    for (const { reject } of this.#pending.values()) {
+      reject(err);
+    }
+    this.#pending.clear();
+    try {
+      this.#rl.close(); // already closed if process exited
+    } catch {}
+    try {
+      this.#proc.stdin.end(); // EPIPE if child already died
+    } catch {}
+    try {
+      this.#proc.stdout.destroy();
+    } catch {}
+    try {
+      this.#proc.kill("SIGKILL"); // ESRCH if already reaped
+    } catch {}
+  }
+
   async shutdown(opts = {}) {
     const { phase1Ms = 100, phase2Ms = 1500 } = opts;
     if (this.#closed) return;

--- a/plugins/gemini/scripts/lib/acp-lifecycle.mjs
+++ b/plugins/gemini/scripts/lib/acp-lifecycle.mjs
@@ -6,9 +6,9 @@ import { runCommand } from "./process.mjs";
 /** Default timeout for the ACP initialize handshake (ms). */
 export const ACP_INIT_TIMEOUT_MS = 30_000;
 
-/** Override via GEMINI_ACP_INIT_TIMEOUT_MS env var for slow machines. */
-function resolveInitTimeoutMs() {
-  const override = process.env.GEMINI_ACP_INIT_TIMEOUT_MS;
+/** Read GEMINI_ACP_INIT_TIMEOUT_MS from the given env, falling back to the default. */
+function resolveInitTimeoutMs(env = process.env) {
+  const override = env.GEMINI_ACP_INIT_TIMEOUT_MS;
   if (override) {
     const parsed = Number.parseInt(override, 10);
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
@@ -67,7 +67,7 @@ export async function spawnAcpClient(opts = {}) {
   const binary = opts.binary ?? "gemini";
   const cwd = opts.cwd ?? process.cwd();
   const env = opts.env ?? process.env;
-  const initTimeoutMs = resolveInitTimeoutMs();
+  const initTimeoutMs = resolveInitTimeoutMs(env);
 
   const flag = await detectAcpFlag(binary);
 

--- a/plugins/gemini/scripts/lib/acp-lifecycle.mjs
+++ b/plugins/gemini/scripts/lib/acp-lifecycle.mjs
@@ -3,6 +3,19 @@ import { spawn } from "node:child_process";
 import { AcpClient, installDefaultHandlers } from "./acp-client.mjs";
 import { runCommand } from "./process.mjs";
 
+/** Default timeout for the ACP initialize handshake (ms). */
+export const ACP_INIT_TIMEOUT_MS = 30_000;
+
+/** Override via GEMINI_ACP_INIT_TIMEOUT_MS env var for slow machines. */
+function resolveInitTimeoutMs() {
+  const override = process.env.GEMINI_ACP_INIT_TIMEOUT_MS;
+  if (override) {
+    const parsed = Number.parseInt(override, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return ACP_INIT_TIMEOUT_MS;
+}
+
 // Cache detected flag per binary to avoid repeated --version calls
 const flagCache = new Map();
 
@@ -42,6 +55,8 @@ export function clearFlagCache() {
 
 /**
  * Spawn a new gemini --acp process, complete the initialize handshake, return connected AcpClient.
+ * Timeout defaults to ACP_INIT_TIMEOUT_MS; override via GEMINI_ACP_INIT_TIMEOUT_MS env var.
+ * On timeout, the spawned process is killed and the error is rethrown.
  * @param {object} [opts]
  * @param {string} [opts.binary="gemini"]
  * @param {string} [opts.cwd]
@@ -52,6 +67,7 @@ export async function spawnAcpClient(opts = {}) {
   const binary = opts.binary ?? "gemini";
   const cwd = opts.cwd ?? process.cwd();
   const env = opts.env ?? process.env;
+  const initTimeoutMs = resolveInitTimeoutMs();
 
   const flag = await detectAcpFlag(binary);
 
@@ -64,13 +80,31 @@ export async function spawnAcpClient(opts = {}) {
   const client = new AcpClient(proc);
   installDefaultHandlers(client);
 
-  const initTimeout = new Promise((_, reject) =>
-    setTimeout(
-      () => reject(new Error("ACP initialize timed out after 10s")),
-      10000,
-    ),
-  );
-  await Promise.race([client.initialize(), initTimeout]);
+  const initPromise = client.initialize();
+  // killImmediately() rejects this promise on timeout; mark it handled so it
+  // doesn't surface as an unhandledRejection.
+  initPromise.catch(() => {});
+
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timeoutHandle;
+  const initTimeout = new Promise((_, reject) => {
+    timeoutHandle = setTimeout(
+      () =>
+        reject(
+          new Error(`ACP initialize timed out after ${initTimeoutMs / 1000}s`),
+        ),
+      initTimeoutMs,
+    );
+  });
+
+  try {
+    await Promise.race([initPromise, initTimeout]);
+  } catch (err) {
+    client.killImmediately(err);
+    throw err;
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
 
   return client;
 }

--- a/tests/acp-lifecycle.test.mjs
+++ b/tests/acp-lifecycle.test.mjs
@@ -67,17 +67,10 @@ test("spawnAcpClient times out and kills the child when gemini never responds to
   const binDir = makeTempDir();
   installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.INIT_HANG);
   clearFlagCache();
-
-  const prev = process.env.GEMINI_ACP_INIT_TIMEOUT_MS;
-  process.env.GEMINI_ACP_INIT_TIMEOUT_MS = "100";
-  try {
-    await assert.rejects(
-      () => spawnAcpClient({ env: buildEnv(binDir) }),
-      /ACP initialize timed out/,
-    );
-    // If the child leaks, the event loop stays open and this test hangs.
-  } finally {
-    if (prev === undefined) delete process.env.GEMINI_ACP_INIT_TIMEOUT_MS;
-    else process.env.GEMINI_ACP_INIT_TIMEOUT_MS = prev;
-  }
+  const env = buildEnv(binDir, { GEMINI_ACP_INIT_TIMEOUT_MS: "100" });
+  await assert.rejects(
+    () => spawnAcpClient({ env }),
+    /ACP initialize timed out/,
+  );
+  // If the child leaks, the event loop stays open and this test hangs.
 });

--- a/tests/acp-lifecycle.test.mjs
+++ b/tests/acp-lifecycle.test.mjs
@@ -1,18 +1,23 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  ACP_INIT_TIMEOUT_MS,
   clearFlagCache,
   createSession,
   detectAcpFlag,
   isAlive,
   spawnAcpClient,
 } from "../plugins/gemini/scripts/lib/acp-lifecycle.mjs";
-import { buildEnv, installFakeGemini } from "./fake-gemini-fixture.mjs";
+import {
+  buildEnv,
+  FAKE_GEMINI_BEHAVIOR,
+  installFakeGemini,
+} from "./fake-gemini-fixture.mjs";
 import { makeTempDir } from "./helpers.mjs";
 
 test("detectAcpFlag returns --acp for gemini >= 0.33.0", async () => {
   const binDir = makeTempDir();
-  installFakeGemini(binDir, "task-ok"); // fake reports 0.33.0
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
   clearFlagCache();
   const origPath = process.env.PATH;
   process.env.PATH = `${binDir}:${origPath}`;
@@ -27,7 +32,7 @@ test("detectAcpFlag returns --acp for gemini >= 0.33.0", async () => {
 
 test("spawnAcpClient connects and completes initialize handshake", async () => {
   const binDir = makeTempDir();
-  installFakeGemini(binDir, "task-ok");
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
   clearFlagCache();
   const client = await spawnAcpClient({ env: buildEnv(binDir) });
   assert.ok(client.pid > 0);
@@ -37,7 +42,7 @@ test("spawnAcpClient connects and completes initialize handshake", async () => {
 
 test("isAlive returns true for a live client", async () => {
   const binDir = makeTempDir();
-  installFakeGemini(binDir, "task-ok");
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
   clearFlagCache();
   const client = await spawnAcpClient({ env: buildEnv(binDir) });
   assert.equal(isAlive(client), true);
@@ -46,10 +51,33 @@ test("isAlive returns true for a live client", async () => {
 
 test("createSession returns a non-empty sessionId", async () => {
   const binDir = makeTempDir();
-  installFakeGemini(binDir, "task-ok");
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
   clearFlagCache();
   const { client, sessionId } = await createSession({ env: buildEnv(binDir) });
   assert.equal(typeof sessionId, "string");
   assert.ok(sessionId.length > 0);
   await client.shutdown();
+});
+
+test("ACP_INIT_TIMEOUT_MS defaults to 30s", () => {
+  assert.equal(ACP_INIT_TIMEOUT_MS, 30_000);
+});
+
+test("spawnAcpClient times out and kills the child when gemini never responds to initialize", async () => {
+  const binDir = makeTempDir();
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.INIT_HANG);
+  clearFlagCache();
+
+  const prev = process.env.GEMINI_ACP_INIT_TIMEOUT_MS;
+  process.env.GEMINI_ACP_INIT_TIMEOUT_MS = "100";
+  try {
+    await assert.rejects(
+      () => spawnAcpClient({ env: buildEnv(binDir) }),
+      /ACP initialize timed out/,
+    );
+    // If the child leaks, the event loop stays open and this test hangs.
+  } finally {
+    if (prev === undefined) delete process.env.GEMINI_ACP_INIT_TIMEOUT_MS;
+    else process.env.GEMINI_ACP_INIT_TIMEOUT_MS = prev;
+  }
 });

--- a/tests/fake-gemini-fixture.mjs
+++ b/tests/fake-gemini-fixture.mjs
@@ -3,7 +3,20 @@ import path from "node:path";
 
 import { writeExecutable } from "./helpers.mjs";
 
-export function installFakeGemini(binDir, behavior = "task-ok") {
+export const FAKE_GEMINI_BEHAVIOR = Object.freeze({
+  TASK_OK: "task-ok",
+  REVIEW_OK: "review-ok",
+  SESSION_LOAD: "session-load",
+  CRASH: "crash",
+  HANG: "hang",
+  PERMISSION: "permission",
+  INIT_HANG: "init-hang",
+});
+
+export function installFakeGemini(
+  binDir,
+  behavior = FAKE_GEMINI_BEHAVIOR.TASK_OK,
+) {
   const statePath = path.join(binDir, "fake-gemini-state.json");
   const scriptPath = path.join(binDir, "gemini");
   const source = `#!/usr/bin/env node
@@ -12,6 +25,7 @@ const readline = require("node:readline");
 
 const STATE_PATH = ${JSON.stringify(statePath)};
 const BEHAVIOR = ${JSON.stringify(behavior)};
+const B = ${JSON.stringify(FAKE_GEMINI_BEHAVIOR)};
 
 function loadState() {
   if (!fs.existsSync(STATE_PATH)) {
@@ -75,6 +89,7 @@ rl.on("line", (line) => {
   try {
     switch (message.method) {
       case "initialize":
+        if (BEHAVIOR === B.INIT_HANG) break; // swallow request, never reply
         send({ id: message.id, result: { protocolVersion: 1, agentCapabilities: {}, agentInfo: { name: "fake-gemini", version: "0.33.0" } } });
         break;
 
@@ -95,7 +110,7 @@ rl.on("line", (line) => {
         }
         fs.writeFileSync(STATE_PATH, JSON.stringify(st, null, 2));
         send({ id: message.id, result: { sessionId } });
-        if (BEHAVIOR === "session-load") {
+        if (BEHAVIOR === B.SESSION_LOAD) {
           send({ method: "session/update", params: { sessionId, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Resuming from history." } } } });
         }
         break;
@@ -127,16 +142,15 @@ rl.on("line", (line) => {
         st.prompts.push({ sessionId, text });
         fs.writeFileSync(STATE_PATH, JSON.stringify(st, null, 2));
 
-        if (BEHAVIOR === "crash") {
+        if (BEHAVIOR === B.CRASH) {
           process.exit(1);
         }
 
-        if (BEHAVIOR === "hang") {
-          // Never respond
-          break;
+        if (BEHAVIOR === B.HANG) {
+          break; // never respond
         }
 
-        if (BEHAVIOR === "permission") {
+        if (BEHAVIOR === B.PERMISSION) {
           send({
             id: 9999,
             method: "session/request_permission",
@@ -164,14 +178,14 @@ rl.on("line", (line) => {
           break;
         }
 
-        if (BEHAVIOR === "review-ok" || BEHAVIOR === "session-load") {
+        if (BEHAVIOR === B.REVIEW_OK || BEHAVIOR === B.SESSION_LOAD) {
           const reviewJson = JSON.stringify({ verdict: "no-issues", summary: "No issues found.", findings: [], next_steps: [] });
           send({ method: "session/update", params: { sessionId, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: reviewJson } } } });
           send({ id: message.id, result: { stopReason: "end_turn" } });
           break;
         }
 
-        // Default: task-ok
+        // default falls through as TASK_OK
         send({ method: "session/update", params: { sessionId, update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Task complete." } } } });
         send({ id: message.id, result: { stopReason: "end_turn" } });
         break;

--- a/tests/fake-gemini-fixture.test.mjs
+++ b/tests/fake-gemini-fixture.test.mjs
@@ -6,11 +6,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { installFakeGemini } from "./fake-gemini-fixture.mjs";
+import {
+  FAKE_GEMINI_BEHAVIOR,
+  installFakeGemini,
+} from "./fake-gemini-fixture.mjs";
 
 test("smoke test -- --version flag works", () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fg-test-"));
-  installFakeGemini(dir, "task-ok");
+  installFakeGemini(dir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
   const result = spawnSync("node", [path.join(dir, "gemini"), "--version"], {
     encoding: "utf8",
   });

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   buildEnv,
+  FAKE_GEMINI_BEHAVIOR,
   installFakeGemini,
   readFakeState,
 } from "./fake-gemini-fixture.mjs";
@@ -17,7 +18,7 @@ const SCRIPT = path.join(PLUGIN_ROOT, "scripts", "gemini-companion.mjs");
 
 test("setup reports ready when fake gemini is installed", () => {
   const binDir = makeTempDir();
-  installFakeGemini(binDir, "task-ok");
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
 
   const result = run("node", [SCRIPT, "setup", "--json"], {
     cwd: ROOT,
@@ -37,7 +38,7 @@ test("task runs and captures output", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
   const statePath = path.join(binDir, "fake-gemini-state.json");
-  installFakeGemini(binDir, "task-ok");
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
   initGitRepo(repo);
 
   const result = run("node", [SCRIPT, "task", "Do the thing"], {
@@ -54,7 +55,7 @@ test("task runs and captures output", () => {
 test("review completes with no-issues result", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
-  installFakeGemini(binDir, "review-ok");
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.REVIEW_OK);
   initGitRepo(repo);
   fs.writeFileSync(path.join(repo, "foo.js"), "const x = 1;\n");
   run("git", ["add", "foo.js"], { cwd: repo });
@@ -82,7 +83,7 @@ test("review completes with no-issues result", () => {
 test("status lists jobs after a task", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
-  installFakeGemini(binDir, "task-ok");
+  installFakeGemini(binDir, FAKE_GEMINI_BEHAVIOR.TASK_OK);
   initGitRepo(repo);
   const env = buildEnv(binDir);
 


### PR DESCRIPTION
Closes #3.

Bumps the ACP initialize timeout from 10s to 30s and adds `GEMINI_ACP_INIT_TIMEOUT_MS` for users who need more. The old code also leaked the spawned `gemini` process when the timeout fired — fixed with a new `AcpClient.killImmediately()` on the failure path.

Test plan:
- [x] `pnpm run ci` (build + biome + 54 tests) passes locally
- [x] New test `init-hang` fake scenario + short env override proves the leak is gone (test completing at all is the anti-leak signal)