### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Gemini plugin for Claude Code — code reviews and task delegation via the Gemini CLI.",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "plugins": [
     {
       "name": "gemini",
       "description": "Use Gemini CLI from Claude Code for code reviews and task delegation.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Avishek Biswas"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## [1.0.1] - 2026-04-19
+
+### Added
+
+- Session resume support for Gemini tasks (#8) (thanks @patelnav)
+- `last-review` subcommand to retrieve the most recent review result (#4) (thanks @Co-Messi)
+- Review→rescue context handoff via per-repo save (#4) (thanks @Co-Messi)
+- Release pipeline with CHANGELOG automation (#14)
+
+### Fixed
+
+- ACP init timeout raised to 30 s; child process is now killed on timeout (#9)
+- `resolveInitTimeoutMs` now reads from the spawned process env, not the parent env (#9)
+- Permission handler updated to nested ACP shape required by Gemini CLI ≥ 0.36.0 (#7) (thanks @GrimoireScribe)
+- Adversarial-review prompt verdicts aligned with JSON schema (#6) (thanks @Co-Messi)
+- EPIPE crash on stdin error; review output aligned with Codex format (#5) (thanks @Co-Messi)
+- Dangling `confidence` reference removed after field was dropped (#5) (thanks @Co-Messi)
+
+### Changed
+
+- README updated with current model aliases and `GEMINI_ACP_INIT_TIMEOUT_MS` documentation (#9)
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@abiswas/gemini-plugin-cc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "description": "Use Gemini CLI from Claude Code to review code or delegate tasks.",

--- a/plugins/gemini/.claude-plugin/plugin.json
+++ b/plugins/gemini/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Use Gemini CLI from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "Avishek Biswas"


### PR DESCRIPTION
## [1.0.1] - 2026-04-19

### Added

- Session resume support for Gemini tasks (#8) (thanks @patelnav)
- `last-review` subcommand to retrieve the most recent review result (#4) (thanks @Co-Messi)
- Review→rescue context handoff via per-repo save (#4) (thanks @Co-Messi)
- Release pipeline with CHANGELOG automation (#14)

### Fixed

- ACP init timeout raised to 30 s; child process is now killed on timeout (#9)
- `resolveInitTimeoutMs` now reads from the spawned process env, not the parent env (#9)
- Permission handler updated to nested ACP shape required by Gemini CLI ≥ 0.36.0 (#7) (thanks @GrimoireScribe)
- Adversarial-review prompt verdicts aligned with JSON schema (#6) (thanks @Co-Messi)
- EPIPE crash on stdin error; review output aligned with Codex format (#5) (thanks @Co-Messi)
- Dangling `confidence` reference removed after field was dropped (#5) (thanks @Co-Messi)

### Changed

- README updated with current model aliases and `GEMINI_ACP_INIT_TIMEOUT_MS` documentation (#9)
