### PR TITLE
fix: add shell:true for Windows .cmd resolution in spawnAcpClient

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
-  "name": "abiswas97-gemini",
+  "name": "yesongh-gemini",
   "owner": {
-    "name": "abiswas97"
+    "name": "yesongh"
   },
   "metadata": {
     "description": "Gemini plugin for Claude Code — code reviews and task delegation via the Gemini CLI.",
@@ -13,7 +13,7 @@
       "description": "Use Gemini CLI from Claude Code for code reviews and task delegation.",
       "version": "1.0.1",
       "author": {
-        "name": "Avishek Biswas"
+        "name": "yesongh"
       },
       "source": "./plugins/gemini"
     }

--- a/plugins/gemini/scripts/lib/acp-lifecycle.mjs
+++ b/plugins/gemini/scripts/lib/acp-lifecycle.mjs
@@ -75,6 +75,7 @@ export async function spawnAcpClient(opts = {}) {
     cwd,
     env,
     stdio: ["pipe", "pipe", "inherit"],
+    shell: process.platform === "win32",
   });
 
   const client = new AcpClient(proc);


### PR DESCRIPTION
On Windows, gemini is installed as gemini.cmd via npm. Node.js spawn() without shell:true cannot resolve .cmd files, causing ENOENT. This matches the pattern already used in process.mjs's runCommand().