### PR TITLE
fix: add shell:true for Windows .cmd resolution in spawnAcpClient

### DIFF
--- a/plugins/gemini/scripts/lib/acp-lifecycle.mjs
+++ b/plugins/gemini/scripts/lib/acp-lifecycle.mjs
@@ -75,6 +75,7 @@ export async function spawnAcpClient(opts = {}) {
     cwd,
     env,
     stdio: ["pipe", "pipe", "inherit"],
+    shell: process.platform === "win32",
   });
 
   const client = new AcpClient(proc);


### PR DESCRIPTION
On Windows, gemini is installed as gemini.cmd via npm. Node.js spawn() without shell:true cannot resolve .cmd files, causing ENOENT. This matches the pattern already used in process.mjs's runCommand().