### PR TITLE
docs: add gemini-cli deprecation notice (June 18, 2026 cutoff) + migration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Gemini plugin for Claude Code
 
+> [!IMPORTANT]
+> **`gemini-cli` deprecation notice — June 18, 2026 cutoff**
+>
+> Google [announced at I/O 2026](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) (May 19) that `gemini-cli` is being replaced by **Antigravity CLI (`agy`)**. Free-tier and AI Pro/Ultra users will stop receiving requests on **June 18, 2026**. After that date, this plugin will silently fail for those user tiers. Gemini Code Assist for Enterprise and Vertex AI authenticated users are not affected.
+>
+> **Migration path:** [`antigravity-plugin-cc`](https://github.com/MarcosNahuel/antigravity-plugin-cc) is a Claude Code plugin that wraps `agy` instead of `gemini-cli`, with a similar slash-command shape plus four extras (`/antigravity:record` browser walkthrough recording to `.webm` + MP4, `/antigravity:scrape` structured URL extraction, `/antigravity:doc-to-md` PDF/docx/image to Markdown, `/antigravity:design-review` UX audit).
+>
+> ```text
+> /plugin marketplace add MarcosNahuel/antigravity-plugin-cc
+> /plugin install antigravity@marcosnahuel-antigravity
+> ```
+
 Use Gemini from inside Claude Code for code reviews or to delegate tasks to Gemini.
 
 Based on [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc), adapted for the Gemini CLI. Also adds `/gemini:task` for direct task delegation.


### PR DESCRIPTION
## Why this PR

Google announced at I/O 2026 (May 19) that `gemini-cli` is being replaced by **Antigravity CLI (`agy`)**, and **stops serving requests for AI Pro/Ultra and free-tier users on June 18, 2026** — about 3 weeks from now.

Users hitting that cutoff will find their `gemini-plugin-cc` installs silently breaking. Right now this README has no signal that the underlying CLI is being deprecated, so users will only discover the issue when their workflows stop working.

This PR adds:

1. A short factual deprecation notice at the top of the README (dated, with the cutoff and which tiers are affected vs unaffected).
2. A link to an upstream-compatible Antigravity migration plugin (`antigravity-plugin-cc`) for users who want to keep their `/<provider>:research`-style workflow without breakage.

The plugin you maintain is excellent and was the direct inspiration for the migration. `antigravity-plugin-cc` mirrors its shape (slash-command-per-task, thin forwarder, no companion runtime) on top of `agy` instead of `gemini-cli`, with four extras for browser walkthrough recording, structured scraping, multimodal document conversion, and UX design review.

## What this PR does NOT do

- It does NOT remove or weaken any current docs.
- It does NOT sunset `gemini-plugin-cc` for existing users — Gemini Code Assist for Enterprise and Vertex AI authenticated users keep working post-cutoff and this plugin remains useful for them.
- It does NOT rebrand anything.

The notice is purely informational so users who Google "gemini-cli deprecated" land somewhere with guidance instead of being silently broken later.

## Diff

One file changed: `README.md` — adds a `> [!IMPORTANT]` callout block right after the H1 title, before the existing intro paragraph. 12 lines added, 0 removed.

## Sources

- Google Developers Blog (May 19, 2026): https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/
- The Register coverage (May 20, 2026): https://www.theregister.com/ai-ml/2026/05/20/bye-bye-gemini-cli-google-nudges-devs-toward-antigravity/
- Antigravity migration plugin: https://github.com/MarcosNahuel/antigravity-plugin-cc

Happy to adjust wording, scope, or position of the notice — your call as the maintainer. If you'd prefer a different framing (eg. only call out the cutoff date without naming a specific migration target, or putting the notice at the bottom under a "Future" section), let me know and I'll update.

Thanks for maintaining this plugin — it's been a clean reference implementation.