### PR TITLE
fix(gemini): recover JSON review when model emits prose before the envelope

### DIFF
--- a/plugins/gemini/scripts/lib/gemini.mjs
+++ b/plugins/gemini/scripts/lib/gemini.mjs
@@ -216,6 +216,30 @@ function buildReviewPrompt(reviewTarget, systemPrompt, focusText) {
 }
 
 /**
+ * Best-effort recovery of a JSON object from model output that contains leading
+ * narration prose and/or markdown fences. Returns the candidate JSON string, or
+ * null if none found. Prefers the LAST fenced ```json block (the review envelope
+ * is typically the final block); falls back to the first-{ .. last-} run.
+ * @param {string} raw
+ * @returns {string|null}
+ */
+function extractJsonCandidate(raw) {
+  if (typeof raw !== "string") return null;
+  const fence = /```(?:json)?\s*([\s\S]*?)```/gi;
+  let m;
+  let lastFenced = null;
+  while ((m = fence.exec(raw)) !== null) {
+    const body = m[1].trim();
+    if (body.startsWith("{")) lastFenced = body;
+  }
+  if (lastFenced) return lastFenced;
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start !== -1 && end > start) return raw.slice(start, end + 1);
+  return null;
+}
+
+/**
  * Parse and validate Gemini review output. Fails closed on any validation failure.
  * @param {string} raw
  * @returns {object} Normalized review result
@@ -231,12 +255,27 @@ export function parseReviewOutput(raw) {
   try {
     parsed = JSON.parse(stripped);
   } catch (err) {
-    const e = new Error(`Review output is not valid JSON: ${err.message}`);
-    // @ts-expect-error
-    e.code = "REVIEW_PARSE_ERROR";
-    // @ts-expect-error
-    e.raw = raw;
-    throw e;
+    // Fallback: the model may stream narration prose BEFORE the JSON envelope
+    // (e.g. "I've checked ...\n```json{...}```"). The leading-fence strip above
+    // only fires when the fence is at offset 0, so prose-first output reaches
+    // JSON.parse and throws — losing an otherwise valid review. Recover it.
+    // Purely additive: clean output already parsed above and never reaches here.
+    const salvaged = extractJsonCandidate(raw);
+    if (salvaged !== null) {
+      try {
+        parsed = JSON.parse(salvaged);
+      } catch {
+        parsed = undefined;
+      }
+    }
+    if (parsed === undefined) {
+      const e = new Error(`Review output is not valid JSON: ${err.message}`);
+      // @ts-expect-error
+      e.code = "REVIEW_PARSE_ERROR";
+      // @ts-expect-error
+      e.raw = raw;
+      throw e;
+    }
   }
 
   const schema = JSON.parse(fs.readFileSync(REVIEW_SCHEMA_PATH, "utf8"));


### PR DESCRIPTION
## Problem

`parseReviewOutput` (`plugins/gemini/scripts/lib/gemini.mjs`) strips a markdown code-fence only when it sits at offset 0:

```js
.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "")
```

When Gemini streams narration **before** the JSON envelope — e.g.

```
I've checked .gitignore. Now let's check reindex_cases.py.
```json
{ "verdict": "...", "findings": [...] }
```
```

— the fence is no longer at offset 0, so `JSON.parse` runs on the prose and throws `REVIEW_PARSE_ERROR`. The entire review (a perfectly valid envelope sitting later in the output) is discarded and the lane reports a failure. This shows up often on research-heavy reviews where the model narrates its checks before converging to JSON.

## Repro

Feed `"some prose\n\`\`\`json\n{...valid review...}\n\`\`\`"` to `parseReviewOutput` → it throws instead of parsing the review that is right there.

## Fix

Additive `extractJsonCandidate` fallback in the `catch`: on parse failure, recover the JSON before giving up — take the **last** fenced ```` ```json ```` block (else the first-`{`..last-`}` run) and parse that; only throw `REVIEW_PARSE_ERROR` if that also fails.

- **Happy path unchanged** — clean output parses on the first `JSON.parse` and never reaches the fallback.
- **Genuinely non-JSON output still throws** `REVIEW_PARSE_ERROR`.

## Test

```
clean output            : OK
fenced-only output      : OK
prose + fenced (the bug): OK   ← now recovered
prose + bare braces     : OK
non-JSON garbage        : throws REVIEW_PARSE_ERROR (unchanged)
```